### PR TITLE
Add postMessage for demo step tracking

### DIFF
--- a/src/pages/DemoPage.tsx
+++ b/src/pages/DemoPage.tsx
@@ -447,6 +447,17 @@ const DemoPage = () => {
     }
   }, [stepSlug]);
 
+  // Notify parent window (collab.open.coop) of step change for feedback context
+  useEffect(() => {
+    if (window.parent !== window) {
+      window.parent.postMessage({
+        type: 'demo-step-change',
+        slug: steps[currentIndex].slug,
+        title: steps[currentIndex].title,
+      }, '*');
+    }
+  }, [currentIndex]);
+
   const step = steps[currentIndex];
 
   const goTo = (index: number) => {


### PR DESCRIPTION
## Summary
- Adds a `useEffect` that posts a message to the parent window whenever the demo step changes
- Enables `collab.open.coop/demo/planet-onboarding` (which embeds the demo in an iframe) to show the current step name in its feedback overlay
- No visual or functional changes to the demo itself

## Message format
```js
{ type: 'demo-step-change', slug: 'chat', title: 'The payoff' }
```

## Test plan
- [x] Open the demo directly at `planet-sepia.vercel.app/#/demo` — should work exactly as before
- [x] Open `collab.open.coop/demo/planet-onboarding` — feedback overlay should show the current step name

🤖 Generated with [Claude Code](https://claude.com/claude-code)